### PR TITLE
Switch to PHP 7.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.2.3
+VERSION := 1.2.4
 PLUGINSLUG := kafkai
 SRCPATH := $(shell pwd)/src
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": ">=7.2.0",
+    "php": ">=7.3.0",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/composer.json
+++ b/src/composer.json
@@ -7,7 +7,7 @@
   ],
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=5.6.0"
+    "php": ">=7.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/inc/Config.php
+++ b/src/inc/Config.php
@@ -50,7 +50,7 @@ class Config {
 	/**
 	 * @var string
 	 */
-	const MINIMUM_PHP_VERSION = '7.2';
+	const MINIMUM_PHP_VERSION = '7.3';
 
 	/**
 	 * @var string

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,8 +3,8 @@ Contributors: niteoweb
 Tags: articles, content, seo, kafkai
 Requires at least: 4.2
 Tested up to: 5.5.3
-Stable tag: 1.2.3
-Requires PHP: 7.2
+Stable tag: 1.2.4
+Requires PHP: 7.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -30,6 +30,9 @@ https://github.com/niteoweb/kafkai-plugin
 
 
 == Changelog ==
+
+= 1.2.4 =
+* Minimum supported PHP version is 7.3
 
 = 1.2.0 =
 * Added 3 new niches


### PR DESCRIPTION
Refs https://github.com/niteoweb/kai/issues/460

Switching plugin to PHP 7.3 because of an issue caused by v7.2 which is described below:

```
$generate_page = add_submenu_page(
  Config::PLUGIN_PREFIX . 'generate',
  esc_html__( 'Generate Article', 'kafkai' ),
  esc_html__( 'Generate Article', 'kafkai' ),
  'manage_options',
  Config::PLUGIN_PREFIX . 'generate',
  array( $this, 'generate' ),
);
```

In the above code, an additional `,` added by the linter triggered the error.